### PR TITLE
Remove obsolete SG ingress rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,6 @@ resource "aws_security_group" "default" {
     to_port     = 5439
     protocol    = "tcp"
     cidr_blocks = var.cidr_blocks
-    self        = true
   }
 
   ingress {


### PR DESCRIPTION
There already is an all ports/protocol rule for the SG, remove the specific (obsolete) one