### PR TITLE
Support AWS Provider V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Terraform module to setup and manage an AWS Redshift cluster
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 3.50.0, < 4.0.0 |
+| aws | >= 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.50.0, < 4.0.0 |
+| aws | >= 4.0.0 |
 
 ## Inputs
 
@@ -26,8 +26,8 @@ Terraform module to setup and manage an AWS Redshift cluster
 | password | Password for the master DB user | `string` | n/a | yes |
 | tags | A mapping of tags to assign to the cluster | `map(string)` | n/a | yes |
 | username | Username for the master DB user | `string` | n/a | yes |
-| additional\_ingress\_rules | n/a | <pre>list(object({<br>    description        = string<br>    from_port          = number<br>    to_port            = number<br>    protocol           = string<br>    security_group_ids = list(string)<br>  }))</pre> | `[]` | no |
 | additional\_egress\_rules | n/a | <pre>list(object({<br>    description        = string<br>    from_port          = number<br>    to_port            = number<br>    protocol           = string<br>    security_group_ids = list(string)<br>    prefix_list_ids    = list(string)<br>  }))</pre> | `[]` | no |
+| additional\_ingress\_rules | n/a | <pre>list(object({<br>    description        = string<br>    from_port          = number<br>    to_port            = number<br>    protocol           = string<br>    security_group_ids = list(string)<br>  }))</pre> | `[]` | no |
 | automated\_snapshot\_retention\_period | The number of days automated snapshots should be retained | `number` | `1` | no |
 | availability\_zones | List of availability zones to deploy Redshift in | `list(string)` | `[]` | no |
 | cluster\_type | The cluster type to use (either `single-node` or `multi-node`) | `string` | `"single-node"` | no |

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.50.0, < 4.0.0"
+      version = ">= 4.0.0"
     }
   }
   required_version = ">= 0.12.0"


### PR DESCRIPTION
This PR enables support for AWS Provider V4.

🚨  S3 resources are replaced with the MCAF S3 module, manually perform a move in the state file before applying this version (new `move` functionality does not support this unfortunately).
