### PR TITLE
Fix EIP deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Terraform module to setup and manage an AWS Redshift cluster
 | Name | Version |
 |------|---------|
 | terraform | >= 1.2.0 |
-| aws | >= 4.9.0 |
+| aws | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 4.9.0 |
+| aws | >= 5.0.0 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -4,9 +4,9 @@ locals {
 }
 
 resource "aws_eip" "default" {
-  count = var.publicly_accessible ? 1 : 0
-  vpc   = true
-  tags  = merge(var.tags, { "Name" = "redshift-${var.name}" })
+  count  = var.publicly_accessible ? 1 : 0
+  domain = "vpc"
+  tags   = merge(var.tags, { "Name" = "redshift-${var.name}" })
 }
 
 resource "aws_security_group" "default" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 5.0.0"
     }
   }
   required_version = ">= 1.2.0"


### PR DESCRIPTION
This PR fixed the deprecation warning on the `aws_eip` resource when running AWS Provider V5