### PR TITLE
Removed deprecated datasource `aws_redshift_service_account`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,34 +99,20 @@ module "logging_bucket" {
   lifecycle_rule = var.lifecycle_rule
 }
 
-data "aws_redshift_service_account" "main" {}
-
 data "aws_iam_policy_document" "logging" {
   statement {
     sid = "Put bucket policy needed for Redshift audit logging"
     actions = [
-      "s3:PutObject"
+      "s3:PutObject",
+      "s3:GetBucketAcl",
     ]
     resources = [
-      "arn:aws:s3:::${var.logging_bucket}/*"
+      "arn:aws:s3:::${var.logging_bucket}",
+      "arn:aws:s3:::${var.logging_bucket}/*",
     ]
     principals {
-      type        = "AWS"
-      identifiers = [data.aws_redshift_service_account.main.arn]
-    }
-  }
-
-  statement {
-    sid = "Get ACL bucket policy needed for Redshift audit logging"
-    actions = [
-      "s3:GetBucketAcl"
-    ]
-    resources = [
-      "arn:aws:s3:::${var.logging_bucket}"
-    ]
-    principals {
-      type        = "AWS"
-      identifiers = [data.aws_redshift_service_account.main.arn]
+      type        = "Service"
+      identifiers = ["redshift.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
Removed deprecated datasource `aws_redshift_service_account`

https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-bucket-permissions

![Screenshot 2024-03-12 at 4 02 36 PM](https://github.com/schubergphilis/terraform-aws-mcaf-redshift/assets/39799163/fbe5d099-3a98-43e2-9b6f-8f56079e4712)
