### PR TITLE
enhancement: Move mcaf S3 to Terraform Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Terraform module to setup and manage an AWS Redshift cluster.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_logging_bucket"></a> [logging\_bucket](#module\_logging\_bucket) | github.com/schubergphilis/terraform-aws-mcaf-s3 | v0.10.0 |
+| <a name="module_logging_bucket"></a> [logging\_bucket](#module\_logging\_bucket) | schubergphilis/mcaf-s3/aws | ~> 0.14 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,9 @@ resource "aws_redshift_parameter_group" "default" {
 module "logging_bucket" {
   count = local.create_logging_bucket
 
-  source         = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.10.0"
+  source  = "schubergphilis/mcaf-s3/aws"
+  version = "~> 0.14"
+
   name           = var.logging.bucket_name
   force_destroy  = var.force_destroy
   policy         = data.aws_iam_policy_document.logging[0].json


### PR DESCRIPTION
This PR moves the S3 module to Terraform.

Also locks in minor version so we get "new features that are backwards compatible"