### PR TITLE
feat: add preferred_maintenance_window variable to Redshift cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Terraform module to setup and manage an AWS Redshift cluster.
 | <a name="input_maintenance_track_name"></a> [maintenance\_track\_name](#input\_maintenance\_track\_name) | The name of the maintenance track to apply to the cluster. | `string` | `"current"` | no |
 | <a name="input_node_type"></a> [node\_type](#input\_node\_type) | The node type to be provisioned for the cluster | `string` | `"dc2.large"` | no |
 | <a name="input_number_of_nodes"></a> [number\_of\_nodes](#input\_number\_of\_nodes) | The number of compute nodes in the cluster | `number` | `1` | no |
+| <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range during which system maintenance can occur, in UTC (e.g. `sat:10:00-sat:10:30`) | `string` | `null` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Whether or not the Redshift cluster will be publicly accessible | `bool` | `false` | no |
 | <a name="input_redshift_subnet_group"></a> [redshift\_subnet\_group](#input\_redshift\_subnet\_group) | Name of Redshift subnet group the cluster should be attached to | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -133,17 +133,18 @@ resource "aws_redshift_cluster" "default" {
   elastic_ip                          = local.elastic_ip
   encrypted                           = true
   #checkov:skip=CKV_AWS_321:User defined
-  enhanced_vpc_routing      = var.enhanced_vpc_routing
-  final_snapshot_identifier = var.final_snapshot_identifier
-  iam_roles                 = var.iam_roles
-  kms_key_id                = var.kms_key_arn
-  maintenance_track_name    = var.maintenance_track_name
-  node_type                 = var.node_type
-  number_of_nodes           = var.number_of_nodes
-  publicly_accessible       = var.publicly_accessible
-  skip_final_snapshot       = var.skip_final_snapshot
-  vpc_security_group_ids    = var.subnet_ids != null && length(var.security_group_ids) == 0 ? [aws_security_group.default[0].id] : var.security_group_ids
-  tags                      = var.tags
+  enhanced_vpc_routing         = var.enhanced_vpc_routing
+  final_snapshot_identifier    = var.final_snapshot_identifier
+  iam_roles                    = var.iam_roles
+  kms_key_id                   = var.kms_key_arn
+  maintenance_track_name       = var.maintenance_track_name
+  node_type                    = var.node_type
+  number_of_nodes              = var.number_of_nodes
+  preferred_maintenance_window = var.preferred_maintenance_window
+  publicly_accessible          = var.publicly_accessible
+  skip_final_snapshot          = var.skip_final_snapshot
+  vpc_security_group_ids       = var.subnet_ids != null && length(var.security_group_ids) == 0 ? [aws_security_group.default[0].id] : var.security_group_ids
+  tags                         = var.tags
 }
 
 resource "aws_redshift_logging" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "password" {
   description = "Password for the master DB user"
 }
 
+variable "preferred_maintenance_window" {
+  type        = string
+  default     = null
+  description = "The weekly time range during which system maintenance can occur, in UTC (e.g. `sat:10:00-sat:10:30`)"
+}
+
 variable "publicly_accessible" {
   type        = bool
   default     = false


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Exposes the `preferred_maintenance_window` argument on `aws_redshift_cluster.default` so consumers can control when AWS performs routine maintenance (e.g. `sat:10:00-sat:10:30`).

Non-breaking: the variable defaults to `null`, which preserves the existing AWS-managed default maintenance window for current consumers. No migration required.

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->
We  have encountered job failures due to overlaps with Redshift maintenance. Since the default window can change monthly, we need to pin it using preferred_maintenance_window

## :pencil: Additional Information

Reference - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#preferred_maintenance_window-1